### PR TITLE
feat: Support async subscribers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Next
+
+Features:
+- **BREAKING**: `async` subscribers are now supported. The `EventDispatcher.dispatch` returns a future. 
+
 ## 1.0.0
 
 - Initial version.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,5 @@
+# Upgrade from v1 to v2
+
+## Asynchronous subscribers
+`EventDispatcher.dispatch` returns a Future. If any subscriber is async and depend 
+on modification of the event itself you need to `await` the result of the call.  

--- a/example/lib/example.dart
+++ b/example/lib/example.dart
@@ -7,6 +7,7 @@ import 'example.event_dispatcher_builder.g.dart';
 
 export 'example.event_dispatcher_builder.g.dart';
 export 'src/fake_handler.dart';
+export 'src/async_fake_handler.dart';
 export 'src/test_event.dart';
 
 @GenerateEventDispatcher()

--- a/example/lib/src/async_fake_handler.dart
+++ b/example/lib/src/async_fake_handler.dart
@@ -1,0 +1,15 @@
+import 'package:catalyst_builder/catalyst_builder.dart';
+import 'package:event_dispatcher_builder/event_dispatcher_builder.dart';
+
+import 'test_event.dart';
+
+@Service(tags: [#eventListener])
+class AsyncFakeHandler {
+  List<String> eventTexts = [];
+
+  @Subscribe()
+  Future<void> onTestEvent(TestEvent event) async {
+    await Future.delayed(Duration(seconds: 2), () {});
+    eventTexts.add(event.name);
+  }
+}

--- a/example/test/integration_test.dart
+++ b/example/test/integration_test.dart
@@ -26,6 +26,17 @@ void main() {
     expect(handler.eventTexts, equals(['foo', 'bar']));
   });
 
+  test('Async event dispatching', () async {
+    var handler = AsyncFakeHandler();
+    expect(handler.eventTexts, isEmpty);
+    eventDispatcher.addHandler(handler);
+    eventDispatcher.addHandler(FakeHandler());
+    var future = eventDispatcher.dispatch(TestEvent(name: '1'));
+    expect(handler.eventTexts, isEmpty);
+    await future;
+    expect(handler.eventTexts, equals(['1']));
+  });
+
   test('Throws a HandlerNotSupportException', () {
     expect(
       () => eventDispatcher.addHandler(InvalidHandler()),

--- a/lib/src/builder/generator/event_dispatcher/methods/dispatch.dart
+++ b/lib/src/builder/generator/event_dispatcher/methods/dispatch.dart
@@ -7,12 +7,14 @@ import '../../symbols.dart';
 cb.Method dispatchTemplate() {
   var subscription$ = cb.refer('subscription');
   var tT = cb.refer('T');
+  var vResult = cb.refer('result');
   return cb.Method((m) {
     m
       ..annotations.add(overrideA)
       ..name = dispatch$.symbol
       ..types.add(tT)
-      ..returns = voidT
+      ..returns = futureOfVoidT
+      ..modifier = cb.MethodModifier.async
       ..requiredParameters.add(cb.Parameter(
         (p) => p
           ..type = tT
@@ -27,7 +29,8 @@ cb.Method dispatchTemplate() {
           cb.Code(' in '),
           subscriptions$[tT].code,
           cb.Code('!) {'),
-          subscription$.call([eventP]).statement,
+          initVar(vResult, subscription$.call([eventP])),
+          IfBuilder(vResult.isA(futureT)).then(vResult.awaited).code,
           cb.Code('}'),
         ])
       ]);

--- a/lib/src/builder/generator/symbols.dart
+++ b/lib/src/builder/generator/symbols.dart
@@ -67,3 +67,9 @@ final overrideA = cb.refer('override');
 
 /// List of dynamic
 final listOfDynamicT = cb.refer('List<dynamic>');
+
+/// Future-void
+final futureOfVoidT = cb.refer('Future<void>', 'dart:async');
+
+/// Future-void
+final futureT = cb.refer('Future', 'dart:async');

--- a/lib/src/event_dispatcher.dart
+++ b/lib/src/event_dispatcher.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
+
 /// This class describes a event dispatcher
 abstract class EventDispatcher {
   /// Add an event [handler] to the event dispatcher.
   void addHandler<T>(T handler, [Type? t]);
 
   /// Dispatch a specific [event].
-  void dispatch<T>(T event);
+  Future<void> dispatch<T>(T event);
 }


### PR DESCRIPTION
Add support for async subscribers. This is a **BREAKING** change since the return type of `EventDispatcher.dispatch` was changed from `void` to `Future<void>`.